### PR TITLE
[PATCH] kernel: Add tri-cluster API to affine IRQs and kthreads to

### DIFF
--- a/include/linux/interrupt.h
+++ b/include/linux/interrupt.h
@@ -61,6 +61,10 @@
  *                interrupt handler after suspending interrupts. For system
  *                wakeup devices users need to implement wakeup detection in
  *                their interrupt handlers.
+ * IRQF_PERF_AFFINE - Interrupt is critical to the overall performance of the
+ *		      system and should be processed on a big CPU.
+ * IRQF_PRIME_AFFINE - Interrupt is critical to the overall performance of the
+ *		       system and should be processed on a prime CPU.
  */
 #define IRQF_SHARED		0x00000080
 #define IRQF_PROBE_SHARED	0x00000100
@@ -74,6 +78,8 @@
 #define IRQF_NO_THREAD		0x00010000
 #define IRQF_EARLY_RESUME	0x00020000
 #define IRQF_COND_SUSPEND	0x00040000
+#define IRQF_PERF_AFFINE	0x00080000
+#define IRQF_PRIME_AFFINE	0x00100000
 
 #define IRQF_TIMER		(__IRQF_TIMER | IRQF_NO_SUSPEND | IRQF_NO_THREAD)
 
@@ -216,10 +222,13 @@ extern void enable_irq(unsigned int irq);
 extern void enable_percpu_irq(unsigned int irq, unsigned int type);
 extern bool irq_percpu_is_enabled(unsigned int irq);
 extern void irq_wake_thread(unsigned int irq, void *dev_id);
+extern void irq_set_perf_affinity(unsigned int irq, unsigned int perf_flag);
 
 /* The following three functions are for the core kernel use only. */
 extern void suspend_device_irqs(void);
 extern void resume_device_irqs(void);
+extern void unaffine_perf_irqs(void);
+extern void reaffine_perf_irqs(bool from_hotplug);
 
 /**
  * struct irq_affinity_notify - context for notification of IRQ affinity changes

--- a/include/linux/irq.h
+++ b/include/linux/irq.h
@@ -210,6 +210,7 @@ struct irq_data {
  * IRQD_CAN_RESERVE		- Can use reservation mode
  * IRQD_MSI_NOMASK_QUIRK	- Non-maskable MSI quirk for affinity change
  *				  required
+ * IRQD_PERF_CRITICAL		- IRQ is performance-critical
  * IRQD_AFFINITY_ON_ACTIVATE	- Affinity is set on activation. Don't call
  *				  irq_chip::irq_set_affinity() when deactivated.
  */
@@ -235,6 +236,7 @@ enum {
 	IRQD_DEFAULT_TRIGGER_SET	= (1 << 25),
 	IRQD_CAN_RESERVE		= (1 << 26),
 	IRQD_MSI_NOMASK_QUIRK		= (1 << 27),
+	IRQD_PERF_CRITICAL		= (1 << 28),
 	IRQD_AFFINITY_ON_ACTIVATE	= (1 << 29),
 };
 

--- a/include/linux/kthread.h
+++ b/include/linux/kthread.h
@@ -52,6 +52,31 @@ bool kthread_is_per_cpu(struct task_struct *k);
 	__k;								   \
 })
 
+/**
+ * kthread_run_perf_critical - create and wake a performance-critical thread.
+ *
+ * Same as kthread_create(), but takes a perf cpumask to affine to.
+ */
+#define kthread_run_perf_critical(perfmask, threadfn, data, namefmt, ...)  \
+({									   \
+	struct task_struct *__k						   \
+		= kthread_create(threadfn, data, namefmt, ## __VA_ARGS__); \
+	if (!IS_ERR(__k)) {						   \
+		BUILD_BUG_ON(perfmask != cpu_lp_mask &&			   \
+			     perfmask != cpu_perf_mask &&		   \
+			     perfmask != cpu_prime_mask);		   \
+		if (perfmask == cpu_prime_mask)				   \
+			__k->pc_flags |= PC_PRIME_AFFINE;		   \
+		else if (perfmask == cpu_perf_mask)			   \
+			__k->pc_flags |= PC_PERF_AFFINE;		   \
+		else							   \
+			__k->pc_flags |= PC_LITTLE_AFFINE;		   \
+		kthread_bind_mask(__k, perfmask);			   \
+		wake_up_process(__k);					   \
+	}								   \
+	__k;								   \
+})
+
 void free_kthread_struct(struct task_struct *k);
 void kthread_bind(struct task_struct *k, unsigned int cpu);
 void kthread_bind_mask(struct task_struct *k, const struct cpumask *mask);

--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -831,6 +831,7 @@ struct task_struct {
 	atomic_t			usage;
 	/* Per task flags (PF_*), defined further below: */
 	unsigned int			flags;
+	unsigned int			pc_flags;
 	unsigned int			ptrace;
 
 #ifdef CONFIG_SMP
@@ -1710,6 +1711,13 @@ extern struct pid *cad_pid;
 #define PF_MUTEX_TESTER		0x20000000	/* Thread belongs to the rt mutex tester */
 #define PF_FREEZER_SKIP		0x40000000	/* Freezer should not count it as freezable */
 #define PF_SUSPEND_TASK		0x80000000      /* This thread called freeze_processes() and should not be frozen */
+
+/*
+ * Perf critical flags
+ */
+#define PC_LITTLE_AFFINE		0x00000001
+#define PC_PERF_AFFINE			0x00000002
+#define PC_PRIME_AFFINE		0x00000004
 
 /*
  * Only the _current_ task can read/write to tsk->flags, but other

--- a/kernel/cpu.c
+++ b/kernel/cpu.c
@@ -1080,7 +1080,18 @@ static int cpu_down_maps_locked(unsigned int cpu, enum cpuhp_state target)
 
 static int do_cpu_down(unsigned int cpu, enum cpuhp_state target)
 {
+	struct cpumask newmask;
 	int err;
+
+	preempt_disable();
+	cpumask_andnot(&newmask, cpu_online_mask, cpumask_of(cpu));
+	preempt_enable();
+
+	/* One big, LITTLE, and prime CPU must remain online */
+	if (!cpumask_intersects(&newmask, cpu_lp_mask) ||
+	    !cpumask_intersects(&newmask, cpu_perf_mask) ||
+	    !cpumask_intersects(&newmask, cpu_prime_mask))
+		return -EINVAL;
 
 	/*
 	 * When cpusets are enabled, the rebuilding of the scheduling
@@ -1313,6 +1324,7 @@ int freeze_secondary_cpus(int primary)
 	int cpu, error = 0;
 
 	cpu_maps_update_begin();
+	unaffine_perf_irqs();
 	if (!cpu_online(primary))
 		primary = cpumask_first(cpu_online_mask);
 	/*
@@ -1402,6 +1414,7 @@ void enable_nonboot_cpus(void)
 	arch_enable_nonboot_cpus_end();
 
 	cpumask_clear(frozen_cpus);
+	reaffine_perf_irqs(false);
 out:
 	cpu_maps_update_done();
 }

--- a/kernel/irq/chip.c
+++ b/kernel/irq/chip.c
@@ -266,10 +266,10 @@ int irq_startup(struct irq_desc *desc, bool resend, bool force)
 	} else {
 		switch (__irq_startup_managed(desc, aff, force)) {
 		case IRQ_STARTUP_NORMAL:
-			if (d->chip->flags & IRQCHIP_AFFINITY_PRE_STARTUP)
-				irq_setup_affinity(desc);
 			ret = __irq_startup(desc);
-			if (!(d->chip->flags & IRQCHIP_AFFINITY_PRE_STARTUP))
+			if (irqd_has_set(&desc->irq_data, IRQD_PERF_CRITICAL))
+				setup_perf_irq_locked(desc, desc->action->flags);
+			else
 				irq_setup_affinity(desc);
 			break;
 		case IRQ_STARTUP_MANAGED:

--- a/kernel/irq/cpuhotplug.c
+++ b/kernel/irq/cpuhotplug.c
@@ -70,6 +70,9 @@ static bool migrate_one_irq(struct irq_desc *desc)
 		return false;
 	}
 
+	if (irqd_has_set(d, IRQD_PERF_CRITICAL))
+		return false;
+
 	/*
 	 * No move required, if:
 	 * - Interrupt is per cpu
@@ -204,12 +207,18 @@ void irq_migrate_all_off_this_cpu(void)
 					    irq, smp_processor_id());
 		}
 	}
+
+	if (!cpumask_test_cpu(smp_processor_id(), cpu_lp_mask))
+		reaffine_perf_irqs(true);
 }
 
 static void irq_restore_affinity_of_irq(struct irq_desc *desc, unsigned int cpu)
 {
 	struct irq_data *data = irq_desc_get_irq_data(desc);
 	const struct cpumask *affinity = irq_data_get_affinity_mask(data);
+
+	if (irqd_has_set(data, IRQD_PERF_CRITICAL))
+		return;
 
 	if (!irqd_affinity_is_managed(data) || !desc->action ||
 	    !irq_data_get_irq_chip(data) || !cpumask_test_cpu(cpu, affinity))
@@ -246,6 +255,9 @@ int irq_affinity_online_cpu(unsigned int cpu)
 		raw_spin_unlock_irq(&desc->lock);
 	}
 	irq_unlock_sparse();
+
+	if (!cpumask_test_cpu(cpu, cpu_lp_mask))
+		reaffine_perf_irqs(true);
 
 	return 0;
 }

--- a/kernel/irq/internals.h
+++ b/kernel/irq/internals.h
@@ -133,6 +133,7 @@ extern int irq_do_set_affinity(struct irq_data *data,
 
 #ifdef CONFIG_SMP
 extern int irq_setup_affinity(struct irq_desc *desc);
+extern void setup_perf_irq_locked(struct irq_desc *desc, unsigned int perf_flag);
 #else
 static inline int irq_setup_affinity(struct irq_desc *desc) { return 0; }
 #endif

--- a/kernel/irq/manage.c
+++ b/kernel/irq/manage.c
@@ -20,8 +20,21 @@
 #include <linux/sched/task.h>
 #include <uapi/linux/sched/types.h>
 #include <linux/task_work.h>
+#include <linux/cpu.h>
 
 #include "internals.h"
+
+struct irq_desc_list {
+	struct list_head list;
+	struct irq_desc *desc;
+	unsigned int perf_flag;
+};
+
+static LIST_HEAD(perf_crit_irqs);
+static DEFINE_RAW_SPINLOCK(perf_irqs_lock);
+static int perf_cpu_index = -1;
+static int prime_cpu_index = -1;
+static bool perf_crit_suspended;
 
 #ifdef CONFIG_IRQ_FORCED_THREADING
 __read_mostly bool force_irqthreads;
@@ -173,7 +186,8 @@ bool irq_can_set_affinity_usr(unsigned int irq)
 	struct irq_desc *desc = irq_to_desc(irq);
 
 	return __irq_can_set_affinity(desc) &&
-		!irqd_affinity_is_managed(&desc->irq_data);
+		!irqd_affinity_is_managed(&desc->irq_data) &&
+		!irqd_has_set(&desc->irq_data, IRQD_PERF_CRITICAL);
 }
 
 /**
@@ -1233,6 +1247,147 @@ setup_irq_thread(struct irqaction *new, unsigned int irq, bool secondary)
 	return 0;
 }
 
+static void add_desc_to_perf_list(struct irq_desc *desc, unsigned int perf_flag)
+{
+	struct irq_desc_list *item;
+
+	item = kmalloc(sizeof(*item), GFP_ATOMIC | __GFP_NOFAIL);
+	item->desc = desc;
+	item->perf_flag = perf_flag;
+
+	raw_spin_lock(&perf_irqs_lock);
+	list_add(&item->list, &perf_crit_irqs);
+	raw_spin_unlock(&perf_irqs_lock);
+}
+
+static void affine_one_perf_thread(struct irqaction *action)
+{
+	const struct cpumask *mask;
+
+	if (!action->thread)
+		return;
+
+	if (action->flags & IRQF_PERF_AFFINE) {
+		mask = cpu_perf_mask;
+		action->thread->pc_flags |= PC_PERF_AFFINE;
+	} else {
+		mask = cpu_prime_mask;
+		action->thread->pc_flags |= PC_PRIME_AFFINE;
+	}
+
+	set_cpus_allowed_ptr(action->thread, mask);
+}
+
+static void unaffine_one_perf_thread(struct irqaction *action)
+{
+	if (!action->thread)
+		return;
+
+	action->thread->pc_flags &= ~PC_PERF_AFFINE;
+	action->thread->pc_flags &= ~PC_PRIME_AFFINE;
+	set_cpus_allowed_ptr(action->thread, cpu_all_mask);
+}
+
+static void affine_one_perf_irq(struct irq_desc *desc, unsigned int perf_flag)
+{
+	const struct cpumask *mask;
+	int *mask_index;
+	int cpu;
+
+	if (perf_flag & IRQF_PERF_AFFINE) {
+		mask = cpu_perf_mask;
+		mask_index = &perf_cpu_index;
+	} else {
+		mask = cpu_prime_mask;
+		mask_index = &prime_cpu_index;
+	}
+
+	if (!cpumask_intersects(mask, cpu_online_mask)) {
+		WARN(1, "requested perf CPU is offline for %s\n", desc->name);
+		irq_set_affinity_locked(&desc->irq_data, cpu_online_mask, true);
+		return;
+	}
+
+	/* Balance the performance-critical IRQs across the given CPUs */
+	while (1) {
+		cpu = cpumask_next_and(*mask_index, mask, cpu_online_mask);
+		if (cpu < nr_cpu_ids)
+			break;
+		*mask_index = -1;
+	}
+	irq_set_affinity_locked(&desc->irq_data, cpumask_of(cpu), true);
+
+	*mask_index = cpu;
+}
+
+void setup_perf_irq_locked(struct irq_desc *desc, unsigned int perf_flag)
+{
+	add_desc_to_perf_list(desc, perf_flag);
+	raw_spin_lock(&perf_irqs_lock);
+	affine_one_perf_irq(desc, perf_flag);
+	raw_spin_unlock(&perf_irqs_lock);
+}
+
+void irq_set_perf_affinity(unsigned int irq, unsigned int perf_flag)
+{
+	struct irq_desc *desc = irq_to_desc(irq);
+	unsigned long flags;
+
+	if (!desc)
+		return;
+
+	raw_spin_lock_irqsave(&desc->lock, flags);
+	if (desc->action) {
+		desc->action->flags |= perf_flag;
+		irqd_set(&desc->irq_data, IRQD_PERF_CRITICAL);
+		setup_perf_irq_locked(desc, perf_flag);
+	} else {
+		WARN(1, "perf affine: action not set for IRQ%d\n", irq);
+	}
+	raw_spin_unlock_irqrestore(&desc->lock, flags);
+}
+
+void unaffine_perf_irqs(void)
+{
+	struct irq_desc_list *data;
+	unsigned long flags;
+
+	raw_spin_lock_irqsave(&perf_irqs_lock, flags);
+	perf_crit_suspended = true;
+	list_for_each_entry(data, &perf_crit_irqs, list) {
+		struct irq_desc *desc = data->desc;
+
+		raw_spin_lock(&desc->lock);
+		irq_set_affinity_locked(&desc->irq_data, cpu_all_mask, true);
+		unaffine_one_perf_thread(desc->action);
+		raw_spin_unlock(&desc->lock);
+	}
+	raw_spin_unlock_irqrestore(&perf_irqs_lock, flags);
+}
+
+void reaffine_perf_irqs(bool from_hotplug)
+{
+	struct irq_desc_list *data;
+	unsigned long flags;
+
+	raw_spin_lock_irqsave(&perf_irqs_lock, flags);
+	/* Don't allow hotplug to reaffine IRQs when resuming from suspend */
+	if (!from_hotplug || !perf_crit_suspended) {
+		perf_crit_suspended = false;
+		perf_cpu_index = -1;
+		prime_cpu_index = -1;
+		list_for_each_entry(data, &perf_crit_irqs, list) {
+			struct irq_desc *desc = data->desc;
+
+			raw_spin_lock(&desc->lock);
+			affine_one_perf_irq(desc, data->perf_flag);
+			affine_one_perf_thread(desc->action);
+			raw_spin_unlock(&desc->lock);
+		}
+	}
+	raw_spin_unlock_irqrestore(&perf_irqs_lock, flags);
+}
+
 /*
  * Internal function to register an irqaction - typically used to
  * allocate special interrupts that are part of the architecture.
@@ -1507,6 +1662,12 @@ __setup_irq(unsigned int irq, struct irq_desc *desc, struct irqaction *new)
 			irqd_set(&desc->irq_data, IRQD_NO_BALANCING);
 		}
 
+		if (new->flags & (IRQF_PERF_AFFINE | IRQF_PRIME_AFFINE)) {
+			affine_one_perf_thread(new);
+			irqd_set(&desc->irq_data, IRQD_PERF_CRITICAL);
+			*old_ptr = new;
+		}
+
 		if (irq_settings_can_autoenable(desc)) {
 			irq_startup(desc, IRQ_RESEND, IRQ_START_COND);
 		} else {
@@ -1531,7 +1692,8 @@ __setup_irq(unsigned int irq, struct irq_desc *desc, struct irqaction *new)
 				irq, omsk, nmsk);
 	}
 
-	*old_ptr = new;
+	if (!irqd_has_set(&desc->irq_data, IRQD_PERF_CRITICAL))
+		*old_ptr = new;
 
 	irq_pm_install_action(desc, new);
 
@@ -1670,6 +1832,20 @@ static struct irqaction *__free_irq(struct irq_desc *desc, void *dev_id)
 		if (action->dev_id == dev_id)
 			break;
 		action_ptr = &action->next;
+	}
+
+	if (irqd_has_set(&desc->irq_data, IRQD_PERF_CRITICAL)) {
+		struct irq_desc_list *data;
+
+		raw_spin_lock(&perf_irqs_lock);
+		list_for_each_entry(data, &perf_crit_irqs, list) {
+			if (data->desc == desc) {
+				list_del(&data->list);
+				kfree(data);
+				break;
+			}
+		}
+		raw_spin_unlock(&perf_irqs_lock);
 	}
 
 	/* Found it - now remove it from the list of entries: */

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -1685,6 +1685,16 @@ static int __set_cpus_allowed_ptr(struct task_struct *p,
 	int ret = 0;
 	cpumask_t allowed_mask;
 
+	/* Don't allow perf-critical threads to have non-perf affinities */
+	if ((p->pc_flags & PC_PRIME_AFFINE) && new_mask != cpu_prime_mask)
+		return -EINVAL;
+
+	if ((p->pc_flags & PC_PERF_AFFINE) && new_mask != cpu_perf_mask)
+		return -EINVAL;
+
+	if ((p->pc_flags & PC_LITTLE_AFFINE) && new_mask != cpu_lp_mask)
+		return -EINVAL;
+
 	rq = task_rq_lock(p, &rf);
 	update_rq_clock(rq);
 


### PR DESCRIPTION
 fast CPUs

On devices with a CPU that contains heterogeneous cores (e.g., big.LITTLE), it can be beneficial to place some performance-critical IRQs and kthreads onto the fast CPU clusters in order to improve performance.

This commit adds the following APIs:
-kthread_run_perf_critical() to create and start a perf-critical kthread
 and affine it to the given performance CPUs
-irq_set_perf_affinity() to mark an active IRQ as perf-critical and
 affine it to the given performance CPUs
-IRQF_PERF_AFFINE and IRQF_PRIME_AFFINE to schedule an IRQ and any
 threads it may have onto the given performance CPUs
-PF_PERF_CRITICAL to mark a process (mainly a kthread) as performance
 critical (this is used by kthread_run_perf_critical())

In order to accommodate this new API, the following changes are made: -Performance-critical IRQs are distributed evenly among online CPUs
 available in the given performance CPU mask
-Performance-critical IRQs have their affinities reaffined upon exit
 from suspend (since the affinities are broken when non-boot CPUs are
 disabled)
-Performance-critical IRQs and their threads have their affinities reset
 upon entering suspend, so that upon immediate suspend exit (when only
 the boot CPU is online), interrupts can be processed and interrupt
 threads can be scheduled onto an online CPU (otherwise we'd hit a
 kernel BUG)
-__set_cpus_allowed_ptr() is modified to enforce a performance-critical
 kthread's affinity
-Perf-critical IRQs aren't allowed to have their affinity changed by
 userspace

Signed-off-by: Sultan Alsawaf <sultan@kerneltoast.com>
Signed-off-by: Adam W. Willis <return.of.octobot@gmail.com>
Signed-off-by: LibXZR <xzr467706992@163.com>